### PR TITLE
PG-1827 : Update haproxy version to 2.8.15

### DIFF
--- a/haproxy-builder.sh
+++ b/haproxy-builder.sh
@@ -440,12 +440,12 @@ RPM_RELEASE=1
 DEB_RELEASE=1
 REVISION=0
 BUILD_REPO=https://github.com/percona/haproxy-packaging.git
-BRANCH="v2.8.17"
+BRANCH="v2.8.15"
 REPO="http://git.haproxy.org/git/haproxy-2.8.git/"
 PRODUCT=percona-haproxy
 DEBUG=0
 parse_arguments PICK-ARGS-FROM-ARGV "$@"
-VERSION='2.8.17'
+VERSION='2.8.15'
 RELEASE='1'
 PRODUCT_FULL=${PRODUCT}-${VERSION}-${RELEASE}
 


### PR DESCRIPTION
[PG-1827](https://perconadev.atlassian.net/browse/PG-1827) : The latest available minor.minor for 2.8.x is 2.8.15